### PR TITLE
Fix invalid workflow file env usage

### DIFF
--- a/.github/workflows/vm-daemon-mlops.yml
+++ b/.github/workflows/vm-daemon-mlops.yml
@@ -147,7 +147,7 @@ jobs:
     name: 🎯 AAR Core Orchestration
     runs-on: ubuntu-latest
     needs: validate-echo-architecture
-    if: needs.validate-echo-architecture.outputs.has-aar-core == 'true' && env.AAR_CORE_ENABLED == 'true'
+    if: needs.validate-echo-architecture.outputs.has-aar-core == 'true' && (github.event.inputs.enable_aar_core == 'true' || github.event.inputs.enable_aar_core == null)
     timeout-minutes: 20
     
     steps:
@@ -222,7 +222,7 @@ jobs:
     name: 🧬 Echo-Self AI Evolution
     runs-on: ubuntu-latest
     needs: validate-echo-architecture
-    if: needs.validate-echo-architecture.outputs.has-echo-self == 'true' && env.ECHO_EVOLUTION_ENABLED == 'true'
+    if: needs.validate-echo-architecture.outputs.has-echo-self == 'true' && (github.event.inputs.enable_echo_evolution == 'true' || github.event.inputs.enable_echo_evolution == null)
     timeout-minutes: 30
     
     steps:


### PR DESCRIPTION
Fix GitHub Actions workflow to use `github.event.inputs` instead of `env` in job-level `if` conditions.

GitHub Actions does not support using `env` context variables directly in job-level `if` conditions; `env` is only available within job steps. This change updates the conditions to correctly reference workflow inputs, ensuring jobs are enabled based on input values or their default state.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca0f43a1-804c-48a2-a5c5-3264a462c2fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca0f43a1-804c-48a2-a5c5-3264a462c2fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

